### PR TITLE
Add an extension to scan for alternate  streams in NTFS filesystems

### DIFF
--- a/meta/ntfs_streams.py
+++ b/meta/ntfs_streams.py
@@ -14,7 +14,7 @@ def find_streams(satori_image, file_path, file_type, os_context):
             ext_logger.info("File path {} is not a valid NTFS path".format(file_path))
             return
 
-        command = "dir \"{}\" /r".format(file_path)
+        command = "dir \"{}\" /A /r".format(file_path)
         stdout = os_context.popen(command).read()
 
         stream_dict = parse_cmd(stdout)

--- a/meta/ntfs_streams.py
+++ b/meta/ntfs_streams.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import os
+from hooker import hook
+
+__name__ = 'ntfs-streams'
+
+@hook("imager.pre_open")
+def find_streams(satori_image, file_path, file_type, os_context):
+
+    if file_type == 'U' or file_type == 'F':
+        command = "dir " + file_path + " /r"
+        stdout = os.popen(command).read()
+
+        stream_dict = parse_cmd(stdout)
+
+        satori_image.set_attribute(file_path, stream_dict, __name__, force_create=True)
+
+def parse_cmd(stdout):
+
+    lines = stdout.splitlines()[5:-2]
+
+    ret = {}
+    for row in lines:
+        try:
+            filename = row.split()[-1]
+        except IndexError:
+            # print(row)
+            continue
+
+        if ":" not in filename:
+            continue
+        fname, alt_stream, stream_type = filename.split(":")
+        ret[alt_stream] = stream_type
+
+    return ret

--- a/meta/ntfs_streams.py
+++ b/meta/ntfs_streams.py
@@ -1,16 +1,21 @@
 # -*- coding: utf-8 -*-
 
-import os
 from hooker import hook
+from satoricore.logger import ext_logger
 
 __name__ = 'ntfs-streams'
 
 @hook("imager.pre_open")
 def find_streams(satori_image, file_path, file_type, os_context):
 
-    if file_type == 'U' or file_type == 'F':
-        command = "dir " + file_path + " /r"
-        stdout = os.popen(command).read()
+    if file_type is 'U' or file_type is 'F':
+
+        if '"' in file_path:
+            ext_logger.info("File path {} is not a valid NTFS path".format(file_path))
+            return
+
+        command = "dir \"{}\" /r".format(file_path)
+        stdout = os_context.popen(command).read()
 
         stream_dict = parse_cmd(stdout)
 
@@ -25,7 +30,6 @@ def parse_cmd(stdout):
         try:
             filename = row.split()[-1]
         except IndexError:
-            # print(row)
             continue
 
         if ":" not in filename:


### PR DESCRIPTION
A new attribute called ntfs-streams is added to all the image's files containing the names of the different streams if any.